### PR TITLE
ci: run the PR gate on the self-hosted ARC runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ permissions:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: resal-arc
+    timeout-minutes: 30
     permissions:
       pull-requests: read # needed for `dorny/paths-filter`
     outputs:
@@ -46,7 +47,8 @@ jobs:
 
   build:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: resal-arc
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -89,7 +91,8 @@ jobs:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: resal-arc
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -103,7 +106,8 @@ jobs:
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   sast:
-    runs-on: ubuntu-latest
+    runs-on: resal-arc
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Moves this repo's PR gate on `main` onto the in-cluster self-hosted ARC runners (`resal-arc`).

Phase 3 of the runner migration only ever landed on `develop`. On `main`, 203 workflow files across
47 repos still run on GitHub-hosted `ubuntu-latest`. This PR is part of the test/PR-gate half of
that sweep — the image-build half is being handled separately, because ARC has no buildx and needs
per-repo Dockerfile evidence first.

## Scope

Only two things change per job: `runs-on: ubuntu-latest` -> `resal-arc`, and an added
`timeout-minutes: 30`. Nothing else — no steps, triggers, versions or expressions.

Each edit was applied mechanically and then re-parsed, and is **refused** unless the structural
diff between the old and new YAML contains nothing but those two keys. 37 files were processed and
0 were refused.

`timeout-minutes` is added deliberately: the ARC pool is finite, and without it a hung job holds a
runner for the 6-hour default.

## How this is proven

This workflow runs on `pull_request`, so **the checks on this PR are the flipped workflow executing
on ARC**. If ARC cannot run this repo's gate, this PR goes red and simply should not be merged —
the change cannot reach `main` unproven.

The same flip has been running on `develop` since 2026-07-22, and the pilot for this sweep
(InventoryMs #702, including a `docker compose` unit-test job on the ARC dind sidecar) passed all
checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
